### PR TITLE
Fix some crashing on console resizing

### DIFF
--- a/HercAndHippoConsole/CycleTimer.cs
+++ b/HercAndHippoConsole/CycleTimer.cs
@@ -6,12 +6,8 @@ namespace HercAndHippoConsole
     {
         private readonly Stopwatch sw;
         public int MillisecondsPerCycle { get; init; }
-        private int halfwayStart;
-        private int halfwayEnd;
         public CycleTimer(int frequencyHz)
         {
-            halfwayStart = MillisecondsPerCycle / 2;
-            halfwayEnd = MillisecondsPerCycle / 1000 + halfwayStart;
             sw = new Stopwatch();
             sw.Start();
             MillisecondsPerCycle = 1000 / frequencyHz;

--- a/HercAndHippoConsole/DisplayLogic.cs
+++ b/HercAndHippoConsole/DisplayLogic.cs
@@ -130,7 +130,6 @@ internal readonly struct DisplayPlan
         {
             DisplayUtilities.ResetConsoleColors();
             Console.Clear();
-            bufferStats.ForceRefresh();
             return false;
         }
         finally

--- a/HercAndHippoConsole/Program.cs
+++ b/HercAndHippoConsole/Program.cs
@@ -47,8 +47,9 @@ while (true)
     lastAction = keyInfo.ToActionInput();
     (state, scrollStatus, nextDisplayPlan) = futures.GetFuturePlan(lastAction);
     refreshed = displayPlan.RefreshDisplay(nextDisplayPlan); // Re-display anything that changed
-    while (!refreshed)
+    while (!refreshed) 
     {
+        bufferStats.ForceRefresh();
         nextDisplayPlan = new DisplayPlan(state, scrollStatus, bufferStats);
         refreshed = displayPlan.RefreshDisplay(nextDisplayPlan);
     }


### PR DESCRIPTION
When resizing the console, Exceptions may be thrown if the code attempts to write to locations that are no longer present. This PR wraps the code that most commonly throws that exception in a try/catch block. Exceptions are still thrown elsewhere, but those are less common.