### PR TITLE
Add Ids to Herc and Hippo objects

### DIFF
--- a/HercAndHippoLibCs/HercAndHippoObj.cs
+++ b/HercAndHippoLibCs/HercAndHippoObj.cs
@@ -4,13 +4,17 @@ namespace HercAndHippoLibCs
 {
     public abstract record HercAndHippoObj 
     {
+        private static int lastId = 0;
         public HercAndHippoObj()
         {
             IsLocatable =  this is ILocatable;
             IsTouchable = this is ITouchable;
             IsShootable = this is IShootable;
             IsCyclable = this is ICyclable;
+            Id = ++lastId;
         }
+        public HercAndHippoObj ForgetId() => this with { Id = 0 };
+        public int Id { get; init; }
         public bool IsLocatable { get; init; }
         public bool IsTouchable { get; init; }
         public bool IsShootable { get; init; }

--- a/HercAndHippoLibCs/HercAndHippoObj.cs
+++ b/HercAndHippoLibCs/HercAndHippoObj.cs
@@ -13,7 +13,6 @@ namespace HercAndHippoLibCs
             IsCyclable = this is ICyclable;
             Id = ++lastId;
         }
-        public HercAndHippoObj ForgetId() => this with { Id = 0 };
         public int Id { get; init; }
         public bool IsLocatable { get; init; }
         public bool IsTouchable { get; init; }
@@ -65,5 +64,13 @@ namespace HercAndHippoLibCs
             return blockers.Where(bl => bl.IsLocatable && !bl.Equals(locatable)).Any();
         }
 
+    }
+
+    public static class HhoExtensions
+    {
+        public static T ForgetId<T>(this T hho) where T : HercAndHippoObj
+        {
+            return hho with { Id = 0 };
+        }
     }
 }

--- a/HercAndHippoLibCs/Interfaces.cs
+++ b/HercAndHippoLibCs/Interfaces.cs
@@ -20,7 +20,7 @@
     public interface ICyclable { Level Cycle(Level level, ActionInput actionInput); }
     public interface ITakeable: ILocatable 
     { 
+        Color Color { get; }
         Level OnTake(Level level); 
-        string Id { get; } 
     }
 }

--- a/HercAndHippoLibCs/Key.cs
+++ b/HercAndHippoLibCs/Key.cs
@@ -4,8 +4,6 @@ public record Key(Color Color, Location Location) : HercAndHippoObj, ILocatable,
     public string ConsoleDisplayString => "♀";
     public Color BackgroundColor => Color.Black;
 
-    public string Id => Color.ToString();
-
     public Level OnTouch(Level level, Direction touchedFrom, ITouchable touchedBy)
     {
         if (touchedBy is Player player)

--- a/HercAndHippoLibCs/Level.cs
+++ b/HercAndHippoLibCs/Level.cs
@@ -4,7 +4,16 @@ public record Level(Player Player, Hippo? Hippo, HashSet<HercAndHippoObj> Second
 {
     public Level ForceSetCycles(int cycles)
     => this with { Cycles = cycles };
-    
+
+    public Level ForgetIds()
+    {
+        Player p2 = Player.ForgetId() as Player ?? throw new NullReferenceException();
+        Hippo? h2 = Hippo?.ForgetId() as Hippo;
+        HashSet<HercAndHippoObj> newSet = SecondaryObjects.Select(hho => hho.ForgetId()).ToHashSet();
+        return this with {Player = p2, Hippo = h2, SecondaryObjects = newSet};
+
+    }
+
     public Level(Player player, Gravity gravity, HashSet<HercAndHippoObj> secondaryObjects, Hippo? hippo = null)
     :this(
         Player: player,
@@ -107,7 +116,7 @@ public record Level(Player Player, Hippo? Hippo, HashSet<HercAndHippoObj> Second
             int hash = Player.GetHashCode() ^ Gravity.GetHashCode();
             if (Hippo != null) hash &= Hippo.GetHashCode();
             foreach (var hho in SecondaryObjects)
-                hash ^= hho.GetHashCode();
+                hash ^= hho.ForgetId().GetHashCode();
             return hash;
         }
     }

--- a/HercAndHippoLibCs/Player.cs
+++ b/HercAndHippoLibCs/Player.cs
@@ -224,16 +224,13 @@ public record Player : HercAndHippoObj, ILocatable, IShootable, ICyclable, ITouc
 
     // Inventory Management
     public Player Take(ITakeable toTake) => this with { Inventory = Inventory.AddItem(toTake) };
-    public bool Has<T>(string id) => Inventory.Contains<T>(id);
-    public bool Has<T>(Color color) => Inventory.Contains<T>(color.ToString());
-    public (bool dropped, ITakeable? item, Player newPlayerState) DropItem<T>(string id)
+    public bool Has<T>(Color color) => Inventory.Contains<T>(color);
+    
+    public (bool dropped, ITakeable? item, Player newPlayerState) DropItem<T>(Color color)
     {
-        (bool dropped, ITakeable? item, Inventory reducedInventory) = Inventory.DropItem<T>(id);
+        (bool dropped, ITakeable? item, Inventory reducedInventory) = Inventory.DropItem<T>(color);
         return (dropped, item, this with { Inventory = reducedInventory });
     }
-
-    public (bool dropped, ITakeable? item, Player newPlayerState) DropItem<T>(Color color)
-     => DropItem<T>(color.ToString());
 
     // Public static utilities
     public static Player Default(Location location) => new(location: location, health: 100, ammoCount: 0, inventory: Inventory.EmptyInventory, jumpStrength: 5, kineticEnergy: 0);

--- a/HercAndHippoLibCsTest/Bullet_Tests.cs
+++ b/HercAndHippoLibCsTest/Bullet_Tests.cs
@@ -120,13 +120,13 @@ namespace HercAndHippoLibCsTest
             Level level = new(player, gravity: Gravity.None, secondaryObjects: new HashSet<HercAndHippoObj>() { corner, initialEastward, initialWestward, initialNorthward, initialSouthward });
 
             // Act
-            level = level.RefreshCyclables(ActionInput.NoAction);
+            level = level.RefreshCyclables(ActionInput.NoAction).ForgetIds();
 
             // Assert
-            Assert.IsTrue(level.Contains(cycledEastward));
-            Assert.IsTrue(level.Contains(cycledNorthward));
-            Assert.IsTrue(level.Contains(cycledWestward));
-            Assert.IsTrue(level.Contains(cycledSouthward));     
+            Assert.IsTrue(level.Contains(cycledEastward.ForgetId()));
+            Assert.IsTrue(level.Contains(cycledNorthward.ForgetId()));
+            Assert.IsTrue(level.Contains(cycledWestward.ForgetId()));
+            Assert.IsTrue(level.Contains(cycledSouthward.ForgetId()));     
         }
 
         [TestMethod]

--- a/HercAndHippoLibCsTest/Bullet_Tests.cs
+++ b/HercAndHippoLibCsTest/Bullet_Tests.cs
@@ -82,21 +82,21 @@ namespace HercAndHippoLibCsTest
         public void BulletMovesPastNonShootableObjects_Test()
         {
             // Arrange
-            Noninteractor nonshootable = new((3, 3));
-            Bullet initialBullet = new((2, 3), Direction.East);
-            Bullet bullet2 = new(nonshootable.Location, Direction.East);
-            Bullet bullet3 = new((4, 3), Direction.East);
+            Noninteractor nonshootable = new Noninteractor((3, 3)).ForgetId();
+            Bullet initialBullet = new Bullet((2, 3), Direction.East).ForgetId();
+            Bullet bullet2 = new Bullet(nonshootable.Location, Direction.East).ForgetId();
+            Bullet bullet3 = new Bullet((4, 3), Direction.East).ForgetId();
             Wall corner = new(Color.Yellow, (10, 10)); // Give bullet room in the level to move past the nonshootable
             Player player = new((3, 2), health: 100, ammoCount: 1, inventory: Inventory.EmptyInventory);
             Level level = new(player, gravity: Gravity.None, secondaryObjects: new HashSet<HercAndHippoObj> { initialBullet, nonshootable, corner });
-
+            
             // Act and assert
-            level = level.RefreshCyclables(ActionInput.NoAction);
+            level = level.RefreshCyclables(ActionInput.NoAction).ForgetIds();
             Assert.IsFalse(level.Contains(initialBullet));
             Assert.IsTrue(level.Contains(bullet2));
             Assert.IsTrue(level.Contains(nonshootable));
 
-            level = level.RefreshCyclables(ActionInput.NoAction);
+            level = level.RefreshCyclables(ActionInput.NoAction).ForgetIds();
             Assert.IsFalse(level.Contains(bullet2));
             Assert.IsTrue(level.Contains(bullet3));
             Assert.IsTrue(level.Contains(nonshootable));

--- a/HercAndHippoLibCsTest/Bullet_Tests.cs
+++ b/HercAndHippoLibCsTest/Bullet_Tests.cs
@@ -49,7 +49,7 @@ namespace HercAndHippoLibCsTest
             // Arrange
             int initialCount = 0;
             Player player = new((3, 2), health: 100, ammoCount: 1, inventory: Inventory.EmptyInventory);
-            ShotCounter initialCounter = new((2, 2), Count: initialCount);
+            ShotCounter initialCounter = new ShotCounter((2, 2), Count: initialCount).ForgetId();
             ShotCounter cycledCounter = initialCounter with { Count = initialCount + 1 };
             Level level = new(player, 
                 gravity: Gravity.None, 
@@ -58,7 +58,9 @@ namespace HercAndHippoLibCsTest
                     initialCounter, 
                     new Wall(Color.Black, (20, 20)) 
                 });
-            Bullet bullet = new(initialCounter.Location, Direction.West);
+            level = level.ForgetIds();
+
+            Bullet bullet = new Bullet(initialCounter.Location, Direction.West).ForgetId();
             Assert.IsTrue(level.Contains(initialCounter));
             Assert.IsFalse(level.Contains(cycledCounter));
             Assert.IsFalse(level.Contains(bullet));
@@ -68,9 +70,9 @@ namespace HercAndHippoLibCsTest
             // If this behavior changes in the future (ie if I decide that the bullet should call OnShot
             // when it is first created), this test will still pass, which is fine; I just want to enforce
             // that OnShot is called at some point before the bullet moves past the object.
-            level = level.RefreshCyclables(ActionInput.ShootWest);
+            level = level.RefreshCyclables(ActionInput.ShootWest).ForgetIds();
             Assert.IsTrue(level.Contains(bullet));
-            level = level.RefreshCyclables(ActionInput.NoAction);
+            level = level.RefreshCyclables(ActionInput.NoAction).ForgetIds();
             // Assert: counter has cycled
             Assert.IsFalse(level.Contains(initialCounter));
             Assert.IsTrue(level.Contains(cycledCounter));

--- a/HercAndHippoLibCsTest/Environment_Tests.cs
+++ b/HercAndHippoLibCsTest/Environment_Tests.cs
@@ -30,11 +30,11 @@ namespace HercAndHippoLibCsTest
             Wall wall = new(Color.White, (4, 2));
             Wall corner = new(Color.White, (10, 10));
             Level level = new(player, gravity: Gravity.None, secondaryObjects: new HashSet<HercAndHippoObj> { wall, corner });
-            Bullet initialBullet = new((3, 2), Direction.East);
-            Bullet bulletOverWall = new(wall.Location, Direction.East);
+            Bullet initialBullet = new Bullet((3, 2), Direction.East).ForgetId();
+            Bullet bulletOverWall = new Bullet(wall.Location, Direction.East).ForgetId();
 
             // Act
-            level = level.RefreshCyclables(ActionInput.ShootEast);
+            level = level.RefreshCyclables(ActionInput.ShootEast).ForgetIds();
             Assert.IsTrue(level.Contains(initialBullet)); // Bullet is between player and wall
             Assert.IsFalse(level.Contains(bulletOverWall));
             // On next cycle, bullet moves to overlap wall. On subsequent cycle, bullet is gone.
@@ -88,11 +88,11 @@ namespace HercAndHippoLibCsTest
             Door door = new(Color.DarkMagenta, (4, 2));
             Wall corner = new(Color.White, (10, 10));
             Level level = new(player, gravity: Gravity.None, secondaryObjects: new HashSet<HercAndHippoObj> { door, corner });
-            Bullet initialBullet = new((3, 2), Direction.East);
-            Bullet bulletOverWall = new(door.Location, Direction.East);
+            Bullet initialBullet = new Bullet((3, 2), Direction.East).ForgetId();
+            Bullet bulletOverWall = new Bullet(door.Location, Direction.East).ForgetId();
 
             // Act
-            level = level.RefreshCyclables(ActionInput.ShootEast);
+            level = level.RefreshCyclables(ActionInput.ShootEast).ForgetIds();
             Assert.IsTrue(level.Contains(initialBullet)); // Bullet is between player and wall
             Assert.IsFalse(level.Contains(bulletOverWall));
             // On next cycle, bullet moves to overlap wall. On subsequent cycle, bullet is gone.

--- a/HercAndHippoLibCsTest/Environment_Tests.cs
+++ b/HercAndHippoLibCsTest/Environment_Tests.cs
@@ -160,12 +160,12 @@ namespace HercAndHippoLibCsTest
             // Act and Assert
             level = level.RefreshCyclables(ActionInput.MoveEast);
             Assert.AreEqual(secondPosition.Location, level.Player.Location); // Player is adjacent to to door after moving east
-            Assert.IsTrue(level.Player.Has<Key>("Cyan"));// Player has picked up the key
+            Assert.IsTrue(level.Player.Has<Key>(Color.Cyan));// Player has picked up the key
             level = level.RefreshCyclables(ActionInput.MoveEast);
             Assert.AreNotEqual(secondPosition.Location, level.Player.Location); // door has not blocked further eastward movement.
             Assert.AreEqual(playerAtDoor.Location, level.Player.Location); // Player has moved over door
             Assert.IsFalse(level.Contains(door)); // No more door!
-            Assert.IsFalse(level.Player.Has<Key>("Cyan")); // Player no longer has key
+            Assert.IsFalse(level.Player.Has<Key>(Color.Cyan)) ; // Player no longer has key
         }
 
         [TestMethod]

--- a/HercAndHippoLibCsTest/Level_Tests.cs
+++ b/HercAndHippoLibCsTest/Level_Tests.cs
@@ -59,16 +59,17 @@ namespace HercAndHippoLibCsTest
             // Arrange
             Player player = new(new Location(Col: 1, Row: 1), health: 100, ammoCount: 5, inventory: EmptyInventory);
             int startCount = 0;
-            CycleCounter initialCounter = new((2, 2), startCount);
-            CycleCounter cycledCounter = new((2, 2), startCount + 1);
+            CycleCounter initialCounter = new CycleCounter((2, 2), startCount).ForgetId();
+            CycleCounter cycledCounter = new CycleCounter((2, 2), startCount + 1).ForgetId();
             Level level = new(player: player, hippo: null, gravity: Gravity.None, secondaryObjects: new HashSet<HercAndHippoObj>() { initialCounter });
+            level = level.ForgetIds();
 
             // Check that we set this up correctly
             Assert.IsTrue(level.Contains(initialCounter));
             Assert.IsFalse(level.Contains(cycledCounter));
 
             // Act
-            level = level.RefreshCyclables(ActionInput.NoAction);
+            level = level.RefreshCyclables(ActionInput.NoAction).ForgetIds();
 
             // Assert
             Assert.IsFalse(level.Contains(initialCounter));

--- a/HercAndHippoLibCsTest/Player_Tests.cs
+++ b/HercAndHippoLibCsTest/Player_Tests.cs
@@ -322,8 +322,8 @@ namespace HercAndHippoLibCsTest
             ImpassableTouchCounter cycledCounter = new((3, 2), startCount + 1);
             Level level = new(player, gravity: Gravity.None, secondaryObjects: new HashSet<HercAndHippoObj>() { initialCounter });
 
-            Assert.IsTrue(level.Contains(initialCounter));
-            Assert.IsFalse(level.Contains(cycledCounter));
+            Assert.IsTrue(level.ForgetIds().Contains(initialCounter.ForgetId()));
+            Assert.IsFalse(level.ForgetIds().Contains(cycledCounter.ForgetId()));
             Assert.AreEqual(player.Location, level.Player.Location);
 
             // Act: player attempts to move east, but is blocked by counter, which increments
@@ -331,8 +331,8 @@ namespace HercAndHippoLibCsTest
 
             // Assert
             // Check that counter has incremented
-            Assert.IsFalse(level.Contains(initialCounter));
-            Assert.IsTrue(level.Contains(cycledCounter));
+            Assert.IsFalse(level.ForgetIds().Contains(initialCounter.ForgetId()));
+            Assert.IsTrue(level.ForgetIds().Contains(cycledCounter.ForgetId()));
             // Check that player has not moved
             Assert.AreEqual(player.Location, level.Player.Location);
         }

--- a/HercAndHippoLibCsTest/Player_Tests.cs
+++ b/HercAndHippoLibCsTest/Player_Tests.cs
@@ -247,9 +247,9 @@ namespace HercAndHippoLibCsTest
             static Inventory GetNewInventory() => new Inventory(new HashSet<ITakeable>()).AddItem(GetNewKey());
             // Arrange
             Inventory p1Inventory = GetNewInventory();
-            Player player1 = new((2, 2), health: 100, ammoCount: 0, inventory: p1Inventory);
+            Player player1 = new Player((2, 2), health: 100, ammoCount: 0, inventory: p1Inventory).ForgetId();
             Inventory p2Inventory = GetNewInventory();
-            Player player2 = new((2, 2), health: 100, ammoCount: 0, inventory: p2Inventory);
+            Player player2 = new Player((2, 2), health: 100, ammoCount: 0, inventory: p2Inventory).ForgetId();
             // Assert
             Assert.AreEqual(player1, player2);
             Assert.AreEqual(player1.Inventory.GetHashCode(), player2.Inventory.GetHashCode());

--- a/HercAndHippoLibCsTest/Player_Tests.cs
+++ b/HercAndHippoLibCsTest/Player_Tests.cs
@@ -229,9 +229,9 @@ namespace HercAndHippoLibCsTest
             static Inventory GetNewInventory() => new(new HashSet<ITakeable>());
             // Arrange
             Inventory p1Inventory = GetNewInventory();
-            Player player1 = new((2, 2), health: 100, ammoCount: 0, inventory: p1Inventory);
+            Player player1 = new Player((2, 2), health: 100, ammoCount: 0, inventory: p1Inventory).ForgetId();
             Inventory p2Inventory = GetNewInventory();
-            Player player2 = new((2, 2), health: 100, ammoCount: 0, inventory: p2Inventory);
+            Player player2 = new Player((2, 2), health: 100, ammoCount: 0, inventory: p2Inventory).ForgetId();
             // Assert
             Assert.AreEqual(player1.Inventory.GetHashCode(), player2.Inventory.GetHashCode());
             Assert.AreEqual(player1, player2);

--- a/HercAndHippoLibCsTest/Player_Tests.cs
+++ b/HercAndHippoLibCsTest/Player_Tests.cs
@@ -321,18 +321,19 @@ namespace HercAndHippoLibCsTest
             ImpassableTouchCounter initialCounter = new((3, 2), startCount);
             ImpassableTouchCounter cycledCounter = new((3, 2), startCount + 1);
             Level level = new(player, gravity: Gravity.None, secondaryObjects: new HashSet<HercAndHippoObj>() { initialCounter });
+            level = level.ForgetIds();
 
-            Assert.IsTrue(level.ForgetIds().Contains(initialCounter.ForgetId()));
-            Assert.IsFalse(level.ForgetIds().Contains(cycledCounter.ForgetId()));
+            Assert.IsTrue(level.Contains(initialCounter.ForgetId()));
+            Assert.IsFalse(level.Contains(cycledCounter.ForgetId()));
             Assert.AreEqual(player.Location, level.Player.Location);
 
             // Act: player attempts to move east, but is blocked by counter, which increments
-            level = level.RefreshCyclables(ActionInput.MoveEast);
+            level = level.RefreshCyclables(ActionInput.MoveEast).ForgetIds();
 
             // Assert
             // Check that counter has incremented
-            Assert.IsFalse(level.ForgetIds().Contains(initialCounter.ForgetId()));
-            Assert.IsTrue(level.ForgetIds().Contains(cycledCounter.ForgetId()));
+            Assert.IsFalse(level.Contains(initialCounter.ForgetId()));
+            Assert.IsTrue(level.Contains(cycledCounter.ForgetId()));
             // Check that player has not moved
             Assert.AreEqual(player.Location, level.Player.Location);
         }
@@ -342,12 +343,13 @@ namespace HercAndHippoLibCsTest
         {
             // Arrange
             Player player = new((5, 5), health: 100, ammoCount: 5, inventory: EmptyInventory);
-            Bullet northBullet = new((5, 4), Direction.North);
-            Bullet eastBullet = new((6, 5), Direction.East);
-            Bullet southBullet = new((5, 6), Direction.South);
-            Bullet westBullet = new((4, 5), Direction.West);
+            Bullet northBullet = new Bullet((5, 4), Direction.North).ForgetId();
+            Bullet eastBullet = new Bullet((6, 5), Direction.East).ForgetId();
+            Bullet southBullet = new Bullet((5, 6), Direction.South).ForgetId();
+            Bullet westBullet = new Bullet((4, 5), Direction.West).ForgetId();
             Wall corner = new(Color.Yellow, (10, 10));
             Level level = new(player, gravity: Gravity.None, secondaryObjects: new HashSet<HercAndHippoObj>() { corner });
+            level = level.ForgetIds();
 
             Assert.IsFalse(level.Contains(northBullet));
             Assert.IsFalse(level.Contains(eastBullet));
@@ -355,13 +357,13 @@ namespace HercAndHippoLibCsTest
             Assert.IsFalse(level.Contains(westBullet));
 
             // Act and Assert
-            level = level.RefreshCyclables(ActionInput.ShootEast);
+            level = level.RefreshCyclables(ActionInput.ShootEast).ForgetIds();
             Assert.IsTrue(level.Contains(eastBullet));
-            level = level.RefreshCyclables(ActionInput.ShootWest);
+            level = level.RefreshCyclables(ActionInput.ShootWest).ForgetIds();
             Assert.IsTrue(level.Contains(westBullet));
-            level = level.RefreshCyclables(ActionInput.ShootNorth);
+            level = level.RefreshCyclables(ActionInput.ShootNorth).ForgetIds();
             Assert.IsTrue(level.Contains(northBullet));
-            level = level.RefreshCyclables(ActionInput.ShootSouth);
+            level = level.RefreshCyclables(ActionInput.ShootSouth).ForgetIds();
             Assert.IsTrue(level.Contains(southBullet));
         }
 
@@ -369,22 +371,23 @@ namespace HercAndHippoLibCsTest
         public void PlayerCanShootWhenOnBoundary_Test()
         {
             // Arrange
-            Bullet westBullet = new((9, 9), Direction.West);
+            Bullet westBullet = new Bullet((9, 9), Direction.West).ForgetId();
             Wall corner = new(Color.Yellow, (10, 10));
             Player player = new((10, 9), health: 100, ammoCount: 5, inventory: EmptyInventory);
             Level level = new(player, gravity: Gravity.None, secondaryObjects: new HashSet<HercAndHippoObj>() { corner });
+            level = level.ForgetIds();
             Assert.IsFalse(level.Contains(westBullet));
 
             // Act
-            level = level.RefreshCyclables(ActionInput.ShootWest);
+            level = level.RefreshCyclables(ActionInput.ShootWest).ForgetIds();
             // Assert
             Assert.IsTrue(level.Contains(westBullet));
 
             // Arrange
             level = level.WithPlayer(player with { Location = (9, 10) }); // west of corner
-            Bullet northBullet = new((9, 9), Direction.North);
+            Bullet northBullet = new Bullet((9, 9), Direction.North).ForgetId();
             // Act
-            level = level.RefreshCyclables(ActionInput.ShootNorth);
+            level = level.RefreshCyclables(ActionInput.ShootNorth).ForgetIds();
             //Assert
             Assert.IsTrue(level.Contains(northBullet));
 


### PR DESCRIPTION
- Add Id member to`HercAndHippoObj` superclass.
- Add `ForgetId()` member to set Id to zero (for testing)
- Add `ForgetIds()` member to `Level` to set all IDs to zero (for testing)
- Deconflict `Id` member in `ITakeable`/`Inventory` logic